### PR TITLE
Add home parameter to user resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,6 +98,7 @@ class gitolite(
     user { $user_name:
       ensure     => present,
       gid        => $group_name,
+      home       => $home_path,
       managehome => true,
     }
   }


### PR DESCRIPTION
The gitolite class provides the ability to use a custom home location
for the user under which gitolite will operate. However, that location
is not passed to the user resource embedded in the class, causing it to
use the system defaults for user home creation. In cases where /home is
unavailable or needs to be relocated, this can be confusing or
nonfunctional.

This commit ensures that the user resource respects the home property as
passed by the `home_path` parameter on the gitolite class.
